### PR TITLE
Combining HRTBs with associated types

### DIFF
--- a/2018/10.md
+++ b/2018/10.md
@@ -47,7 +47,10 @@ Available.
 Level: Any
 Time: 16:30 - 17:00 (UTC-4)
 
-Available.
+Alec Mocatta – Combining HRTBs with associated types<br/>
+(preferred) Email: alec@mocatta.net<br/>
+Discord: alecmocatta#8569<br/>
+Twitter: [@alecmocatta](https://twitter.com/alecmocatta)
 
 **Monday, Oct 22.**
 


### PR DESCRIPTION
I'm working on data-parallelism library, heavily inspired by Rayon but focused on describing certain computations on a dataset in an SQL-like manner, somewhat akin to Diesel.

One part of this combines HRTBs with associated types. I've bumped into a few issues that have made things a bit tricky ([#30472](https://github.com/rust-lang/rust/issues/30472), [#30867](https://github.com/rust-lang/rust/issues/30867), [#53943](https://github.com/rust-lang/rust/issues/53943), and similar), the hardest to work around however has been that I don't believe it's currently possible to write this:
```rust
type Task = for<'a> <B as Abc<&'a A::Item>>::Task;
```
Currently I've resorted to a dummy trait, manually reimplemented on various structs without the reference, such that I can do:
```rust
type Task = <B as AbcDummy<A::Item>>::Task;
```
and (horribly) transmute between the two.

I'd be very interested to discuss

 1) issues I've bumped into combining HRTBs and associated types;
 2) how to get rid of this transmute and the dummy trait;
 3) any feedback on the library before I publish and promote it, given it's heavily inspired by your work on Rayon!

I can do any of the Monday or Friday times listed, though I have a preference for the 16 - 16.30 slots.

Again, much appreciation for you doing this, I think it's awesome!